### PR TITLE
Fix rewrite rule regex

### DIFF
--- a/utils/infix-to-prefix/Extractor.py
+++ b/utils/infix-to-prefix/Extractor.py
@@ -14,7 +14,7 @@ def extract(path):
               'op->type', 'op->type', 'Call', 'this', 'IRMatcher']
     rules = []
     for line in txtfile:
-        rule = re.search('rewrite\((.*)\) *\|\|$', line)
+        rule = re.search('rewrite\((.*)\)', line)
         if rule:
             formated_rule = [r for r in rule.group(1)]
             formated_rule = ''.join(formated_rule)


### PR DESCRIPTION
The current regex does not match rules having an end of line comment ([example](https://github.com/halide/Halide/blob/bafd60f5bbc0615c307018aa7a3245701cf00c1c/src/Simplify_Mod.cpp#L87)) or an open curly bracket ([example](https://github.com/halide/Halide/blob/bafd60f5bbc0615c307018aa7a3245701cf00c1c/src/Simplify_Add.cpp#L35))